### PR TITLE
Viewer: default datadir to /tmp, show url

### DIFF
--- a/plop/viewer.py
+++ b/plop/viewer.py
@@ -13,7 +13,7 @@ from plop.callgraph import CallGraph
 define('port', default=8888)
 define('debug', default=False)
 define('address', default='')
-define('datadir', default=os.path.join(os.path.dirname(__file__), 'test/testdata/'))
+define('datadir', default='/tmp')
 
 class IndexHandler(RequestHandler):
     def get(self):
@@ -102,6 +102,7 @@ def main():
 
     app = Application(handlers, **settings)
     app.listen(options.port, address=options.address)
+    print "Access the viewer at http://localhost:8888"
     IOLoop.instance().start()
 
 if __name__ == '__main__':


### PR DESCRIPTION
Two changes to viewer:
- Change the default datadir to /tmp. This makes it symmetric
  with using "-m plop.collector", which puts data in /tmp.

Print out the URL when the viewer runs, in case the user has
forgotten what port it's running on.
