### PR TITLE
Bugfix: add missing `force-flat.html` to `setup.py`.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ setup(
         "plop": [
             "templates/index.html",
             "templates/force.html",
+            "templates/force-flat.html",
             "static/force.js",
             "static/third_party/d3/d3.v2.js",
             ],


### PR DESCRIPTION
The exception is like this:

```
Traceback (most recent call last):
  File "/home/vagrant/envs/plop-demo/local/lib/python2.7/site-packages/tornado/web.py", line 1021, in _execute
    getattr(self, self.request.method.lower())(*args, **kwargs)
  File "/home/vagrant/envs/plop-demo/lib/python2.7/site-packages/plop/viewer.py", line 35, in get
    data=profile_to_json(self.get_argument('filename')))
  File "/home/vagrant/envs/plop-demo/local/lib/python2.7/site-packages/tornado/web.py", line 498, in render
    html = self.render_string(template_name, **kwargs)
  File "/home/vagrant/envs/plop-demo/local/lib/python2.7/site-packages/tornado/web.py", line 602, in render_string
    t = loader.load(template_name)
  File "/home/vagrant/envs/plop-demo/local/lib/python2.7/site-packages/tornado/template.py", line 324, in load
    self.templates[name] = self._create_template(name)
  File "/home/vagrant/envs/plop-demo/local/lib/python2.7/site-packages/tornado/template.py", line 355, in _create_template
    f = open(path, "rb")
IOError: [Errno 2] No such file or directory: '/home/vagrant/envs/plop-demo/lib/python2.7/site-packages/plop/templates/force-flat.html'
```
