### PR TITLE
Open files in binary mode

### DIFF
--- a/plop/collector.py
+++ b/plop/collector.py
@@ -79,7 +79,7 @@ class CollectorFormatter(object):
         raise Exception("not implemented")
 
     def store(self, collector, filename):
-        with open(filename, "w") as f:
+        with open(filename, "wb") as f:
             f.write(self.format(collector))
 
 


### PR DESCRIPTION
Makes no difference in Python 2 on POSIX systems, but it would/will in Python 3 so probably a good idea to get it right early on.