### PR TITLE
Modernize flame formatter

### DIFF
--- a/plop/collector.py
+++ b/plop/collector.py
@@ -120,8 +120,7 @@ class FlamegraphFormatter(CollectorFormatter):
         return output
 
     def format_flame(self, stack):
-        stack.reverse()
-        funcs = map(lambda stack: "%s (%s:%s)" % (stack[2], stack[0], stack[1]), stack)
+        funcs = map("{0[2]} ({0[0]}:{0[1]})".format, reversed(stack))
         return ";".join(funcs)
 
 


### PR DESCRIPTION
* `reversed` on a list just creates a reverse iterator and is almost free, `lst.reverse()` has to actually reverse the list in-place
* format is somewhat more flexible (alternatively, a listcomp with an old-style format)