### PR TITLE
Update tests for Tornado 5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@
 language: python
 python:
   - 2.7
+  - 3.6
 
 install:
-  - travis_retry pip install -r requirements.txt
+  - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then travis_retry pip install -r requirements-py27.txt; else travis_retry pip install -r requirements.txt; fi
 
 script:
   - python -m plop.test.runtests

--- a/plop/test/callgraph_test.py
+++ b/plop/test/callgraph_test.py
@@ -1,9 +1,9 @@
 import logging
-from tornado.testing import LogTrapTestCase
+import unittest
 
 from plop.callgraph import CallGraph, Node
 
-class SimpleCallgraphTest(LogTrapTestCase):
+class SimpleCallgraphTest(unittest.TestCase):
     def setUp(self):
         graph = CallGraph()
         graph.add_stack([Node(1), Node(2)], dict(time=1))
@@ -13,14 +13,14 @@ class SimpleCallgraphTest(LogTrapTestCase):
         self.graph = graph
 
     def test_basic_attrs(self):
-        logging.info(self.graph.nodes)
-        logging.info(self.graph.edges)
+        logging.debug(self.graph.nodes)
+        logging.debug(self.graph.edges)
         self.assertEqual(len(self.graph.nodes), 4)
         self.assertEqual(len(self.graph.edges), 5)
-                
+
     def test_top_edges(self):
         top_edges = self.graph.get_top_edges('time', 3)
-        logging.info(top_edges)
+        logging.debug(top_edges)
         summary = [(e.parent.id, e.child.id, e.weights['time']) for e in top_edges]
         self.assertEqual(summary, [
                 (2, 3, 9),
@@ -30,7 +30,7 @@ class SimpleCallgraphTest(LogTrapTestCase):
 
     def test_top_nodes(self):
         top_nodes = self.graph.get_top_nodes('time', 2)
-        logging.info(top_nodes)
+        logging.debug(top_nodes)
         summary = [(n.id, n.weights['time']) for n in top_nodes]
         self.assertEqual(summary, [
                 (3, 12),

--- a/requirements-py27.txt
+++ b/requirements-py27.txt
@@ -1,0 +1,2 @@
+tornado<6.0
+six

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,12 @@
 [tox]
-envlist = py27,py34
+envlist = py27,py36
 
 [testenv]
 commands = python -m plop.test.runtests {posargs:}
 changedir = {toxworkdir}
-deps = tornado>=2.2.1
+
+[testenv:py27]
+deps = tornado<6.0
+
+[testenv:py36]
+deps = tornado


### PR DESCRIPTION
Also run CI on python 3, and future-proof for Tornado 6.0.

Fixes #33